### PR TITLE
chore(actions): tidy up workflows

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -13,9 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action != 'edited'
+      checks: write
     steps:
       - name: checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -25,28 +23,9 @@ jobs:
         uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
           reporter: github-pr-review
-          pattern: |
-            gh-squash-merge
-          fail_on_error: true
+          fail_level: error
+          check_all_files_with_shebangs: "true"
           github_token: ${{ secrets.github_token }}
-
-  committed:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action != 'edited'
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: committed
-        uses: crate-ci/committed@bb02f309663f9baced8dbd5fdd80c6369ddf3efd # v1.1.8
-        with:
-          args: --no-merge-commit
 
   # Check the PR title conforms to 'conventional'
   pr-title:
@@ -54,38 +33,19 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    if: |
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'edited' || github.event.action == 'opened')
     steps:
       - run: |
           regexp="^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|deps)(\(.+\))?(!)?: "
-          title="${{ github.event.pull_request.title }}"
-          if [[ ! $title =~ $regexp ]]; then
+          if [[ ! $PR_TITLE =~ $regexp ]]; then
             echo "PR Title is not 'conventional' matching $regexp" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
-
-  typos:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action != 'edited'
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-      - name: typos
-        uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06 # v1.40.0
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
 
   dependabot-merge-trigger:
     needs:
       - shellcheck
-      - committed
-      - typos
       - pr-title
     permissions:
       contents: write

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -11,6 +11,10 @@ jobs:
   actions_merge:
     runs-on: ubuntu-latest
     name: Dependabot Merge (action changes)
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
     steps:
       - name: Checkout branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -30,4 +34,3 @@ jobs:
         uses: quotidian-ennui/actions-olio/dependabot-merge@main
         with:
           token: ${{ steps.app-token.outputs.token }}
-

--- a/committed.toml
+++ b/committed.toml
@@ -1,5 +1,0 @@
-style="conventional"
-allowed_types=["fix", "feat", "chore", "docs", "doc", "style", "refactor", "perf", "test", "build", "deps", "ci"]
-ignore_author_re="(dependabot|renovate)"
-subject_capitalized=false
-subject_not_punctuated=false


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- remove committed action
- remove typos action
- add permissions to dependabot-merge
- remove filters on shellcheck+pr title
<!-- SQUASH_MERGE_END -->

